### PR TITLE
allow send_packet to fail and abort send loop

### DIFF
--- a/src/kowhai_protocol_server.c
+++ b/src/kowhai_protocol_server.c
@@ -168,7 +168,8 @@ void _send_id_list(struct kowhai_protocol_server_t* server, struct kowhai_protoc
         prot->payload.spec.id_list.size = (uint16_t)max_payload_size;
         prot->payload.buffer = (char*)id_list + prot->payload.spec.id_list.offset;
         kowhai_protocol_create(server->packet_buffer, server->max_packet_size, prot, &bytes_required);
-        server->send_packet(server, server->send_packet_param, server->packet_buffer, bytes_required, prot);
+        if (!server->send_packet(server, server->send_packet_param, server->packet_buffer, bytes_required, prot))
+            return;
         // increment payload offset and decrement remaining payload size
         prot->payload.spec.id_list.offset += (uint16_t)max_payload_size;
         size -= max_payload_size;
@@ -238,7 +239,8 @@ void _send_string_list(struct kowhai_protocol_server_t* server, struct kowhai_pr
         prot->payload.spec.string_list.size = (uint16_t)max_payload_size;
         _copy_string_list_to_buffer(string_list, string_list_count, prot->payload.spec.string_list.offset, prot->payload.buffer, max_payload_size);
         kowhai_protocol_create(server->packet_buffer, server->max_packet_size, prot, &bytes_required);
-        server->send_packet(server, server->send_packet_param, server->packet_buffer, bytes_required, prot);
+        if (!server->send_packet(server, server->send_packet_param, server->packet_buffer, bytes_required, prot))
+            return;
         // increment payload offset and decrement remaining payload size
         prot->payload.spec.string_list.offset += (uint16_t)max_payload_size;
         size -= max_payload_size;
@@ -432,7 +434,8 @@ int kowhai_server_process_packet(struct kowhai_protocol_server_t* server, void* 
                     prot.payload.spec.data.memory.size = (uint16_t)max_payload_size;
                     kowhai_read(&tree, prot.payload.spec.data.symbols.count, prot.payload.spec.data.symbols.array_, prot.payload.spec.data.memory.offset, prot.payload.buffer, prot.payload.spec.data.memory.size);
                     kowhai_protocol_create(server->packet_buffer, server->max_packet_size, &prot, &bytes_required);
-                    server->send_packet(server, server->send_packet_param, server->packet_buffer, bytes_required, &prot);
+                    if (!server->send_packet(server, server->send_packet_param, server->packet_buffer, bytes_required, &prot))
+                        return KOW_STATUS_OK;
                     // increment payload offset and decrement remaining payload size
                     prot.payload.spec.data.memory.offset += (uint16_t)max_payload_size;
                     size -= max_payload_size;
@@ -480,7 +483,8 @@ int kowhai_server_process_packet(struct kowhai_protocol_server_t* server, void* 
                 prot.payload.spec.descriptor.size = (uint16_t)max_payload_size;
                 prot.payload.buffer = (char*)tree.desc + prot.payload.spec.descriptor.offset;
                 kowhai_protocol_create(server->packet_buffer, server->max_packet_size, &prot, &bytes_required);
-                server->send_packet(server, server->send_packet_param, server->packet_buffer, bytes_required, &prot);
+                if (!server->send_packet(server, server->send_packet_param, server->packet_buffer, bytes_required, &prot))
+                    return KOW_STATUS_OK;
                 // increment payload offset and decrement remaining payload size
                 prot.payload.spec.descriptor.offset += (uint16_t)max_payload_size;
                 size -= max_payload_size;
@@ -586,7 +590,8 @@ int kowhai_server_process_packet(struct kowhai_protocol_server_t* server, void* 
                                         prot.payload.spec.function_call.size = (uint16_t)max_payload_size;
                                         prot.payload.buffer = (char*)tree.data + prot.payload.spec.function_call.offset;
                                         kowhai_protocol_create(server->packet_buffer, server->max_packet_size, &prot, &bytes_required);
-                                        server->send_packet(server, server->send_packet_param, server->packet_buffer, bytes_required, &prot);
+                                        if (!server->send_packet(server, server->send_packet_param, server->packet_buffer, bytes_required, &prot))
+                                            return KOW_STATUS_OK;
                                         // increment payload offset and decrement remaining payload size
                                         prot.payload.spec.function_call.offset += (uint16_t)max_payload_size;
                                         size -= max_payload_size;
@@ -669,7 +674,8 @@ int kowhai_server_process_event(struct kowhai_protocol_server_t* server, uint16_
         prot.payload.spec.event.size = (uint16_t)max_payload_size;
         prot.payload.buffer = (char*)buffer + prot.payload.spec.event.offset;
         kowhai_protocol_create(server->packet_buffer, server->max_packet_size, &prot, &bytes_required);
-        server->send_packet(server, server->send_packet_param, server->packet_buffer, bytes_required, &prot);
+        if (!server->send_packet(server, server->send_packet_param, server->packet_buffer, bytes_required, &prot))
+            return KOW_STATUS_OK;
         // increment payload offset and decrement remaining payload size
         prot.payload.spec.event.offset += (uint16_t)max_payload_size;
         buffer_size -= max_payload_size;

--- a/src/kowhai_protocol_server.h
+++ b/src/kowhai_protocol_server.h
@@ -15,7 +15,7 @@ typedef struct kowhai_protocol_server_t* pkowhai_protocol_server_t;
  * @param packet_size bytes in the packet buffer
  * @param protocol pointer to the protocol object that generated the packet
  */
-typedef void (*kowhai_send_packet_t)(pkowhai_protocol_server_t server, void* param, void* packet, size_t packet_size, struct kowhai_protocol_t* protocol);
+typedef int (*kowhai_send_packet_t)(pkowhai_protocol_server_t server, void* param, void* packet, size_t packet_size, struct kowhai_protocol_t* protocol);
 
 /**
  * @brief called before node has been written via the kowhai protocol


### PR DESCRIPTION
if send_packet were to fail (which it can now cause it has a return
code) then rather than just fail that one packet and try the next one
and need to fail again and again the whole transfer is aborted ... the
use case for this is the write times out after some long time time say
100ms, but we have 1000 packets to write for sending a large amount of
data (say settings) ... now the for some reason the coms fail and we sit
in a loop trying over and over, but we block everything else for 1000 *
100ms 100,000ms or 100s which makes everything stop for 100s which is
terrible !!! ... so now if a fail happens we simply just abort the whole
lot and fail the send